### PR TITLE
This line installs texlive-xetex

### DIFF
--- a/supporting/Dockerfile
+++ b/supporting/Dockerfile
@@ -31,5 +31,6 @@ RUN sudo mkdir /etc/guacamole/ && \
 #    cp /tmp/gittex/jupyterlab_proxy_texmaker/supporting/guacamole-auth-noauth-1.2.0.jar /etc/guacamole/extensions && \
 #    sudo mkdir -p /etc/guacamole/lib  && \
 #    cp /tmp/gittex/jupyterlab_proxy_texmaker/supporting/guacamole-auth-noauth-1.2.0.jar /etc/guacamole/lib    
-    
+
+RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -y texlive-xetex texlive-fonts-recommended texlive-generic-recommended
 RUN cd /tmp/gittex/jupyterlab_proxy_texmaker && pip install .


### PR DESCRIPTION
This allows users to export notebooks as pdf. Without this package, the export to pdf usually errors out. I was able to test this in https://cloud-shiny.domino.tech/environments/60679d99c9e77c0007e3a8ed#overview and the export to pdf worked like a charm!